### PR TITLE
unimux: Get rid of dnssd

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule UniMux.Mixfile do
     [{:lager, "~> 2.1.1", override: true},
      {:goldrush, github: "DeadZen/goldrush", tag: "0.1.6", override: true},
      {:hello, github: "travelping/hello", branch: "master"},
-     {:metricman, github: "xerions/metricman", branch: "master"}, 
+     {:metricman, github: "xerions/metricman", branch: "master"},
      {:exlager, github: "xerions/exlager"},
      {:exrun, github: "liveforeverx/exrun"},
      {:exrm, github: "xerions/exrm", override: true},

--- a/mix.lock
+++ b/mix.lock
@@ -5,7 +5,6 @@
   "coverex": {:git, "https://github.com/alfert/coverex.git", "38c21c9cfac5e5df27cad0f4d8467fd94e824434", [tag: "v1.4.3"]},
   "cowboy": {:hex, :cowboy, "1.0.2"},
   "cowlib": {:hex, :cowlib, "1.0.1"},
-  "dnssd": {:git, "git://github.com/benoitc/dnssd_erlang.git", "9b2fdb7ff9618102d82f04e4c68ce191c9aa15ba", [branch: "master"]},
   "edown": {:git, "https://github.com/uwiger/edown.git", "c770057f72d2163c718b26e49c572aefe0798ca9", [branch: "master"]},
   "erlware_commons": {:hex, :erlware_commons, "0.15.0"},
   "ex_uri": {:git, "https://github.com/heroku/ex_uri.git", "16f26db7026493d2934f615f8884fad42675f00e", [branch: "master"]},


### PR DESCRIPTION
This patch removes dnssd dependency from the unimux.

(related to the https://github.com/carosio/unimux/issues/19 issue)
