### PR TITLE
Add configurable options for each route

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -4,10 +4,12 @@ use Mix.Config
 
 
 config :unimux,
-  routes: [{"APIPrefix", 'http://127.0.0.1:8080'}],
+  routes: [{"APIPrefix", 'http://127.0.0.1:8080', 10000}],
   listen: 'zmq-tcp://127.0.0.1:20000'
 
 metricman_config = "deps/metricman/config/config.exs"
 if File.exists? metricman_config do
   import_config "../" <> metricman_config
 end
+
+config :setup, :home, '/tmp'

--- a/config/unimux.schema.exs
+++ b/config/unimux.schema.exs
@@ -27,12 +27,18 @@
       doc: "Route API endpoint in form of <protocol>://<host>[:<port>]",
       to: "unimux.routes",
       datatype: :string,
-      default: "http://127.0.0.1:8080"
+      default: "http://127.0.0.1:8080",
+    ],
+    "route.*.timeout": [
+      doc: "Timeout for client call for API endpoint in ms",
+      to: "unimux.routes",
+      datatype: :integer,
+      default: 10000
     ]
   ],
   translations: [
     "unimux.routes.*": fn _, {key, value_map}, acc ->
-      [{value_map[:pattern], value_map[:target]} | acc]
+      [{value_map[:pattern], value_map[:target], value_map[:timeout]} | acc]
     end,
     "listen": fn
       _, uri, acc ->

--- a/test/unimux_test.exs
+++ b/test/unimux_test.exs
@@ -6,22 +6,32 @@ defmodule UniMuxTest do
   require Record
   Record.defrecordp(:context, Record.extract(:context, from_lib: "hello/include/hello.hrl"))
 
+  setup do
+    on_exit fn -> 
+      Application.put_env(:unimux, :routes, [])
+    end
+  end
+
   test "handle request - not found" do
     state = []
     assert {:stop, :not_found, {:ok, :not_found}, state} == UniMux.handle_request(:context, "a.b.c", [], state)
   end
 
-  test_with_mock "handle request - ok", :hello_client, [call: fn(name, _) -> {:ok, name} end] do
+  test_with_mock "handle request - ok", :hello_client, [call: fn(name, _, timeout) -> {:ok, name, timeout} end] do
     state = []
-    Application.put_env(:unimux, :routes, [{"a", 'http://127.0.0.1:8080'}])
-    assert UniMux.handle_request(:context, "a.b.c", [], state) == {:stop, :normal, {:ok, :hello_client_a}, state}  
-    Application.put_env(:unimux, :routes, [{"a", 'http://127.0.0.1:8080'}, {"a.b", "http://127.0.0.1:8081"}])
-    assert UniMux.handle_request(:context, "a.b.c", [], state) == {:stop, :normal, {:ok, :"hello_client_a.b"}, state}
-    Application.put_env(:unimux, :routes, [])
+    Application.put_env(:unimux, :routes, [{"a", 'http://127.0.0.1:8080', 10000}])
+    assert UniMux.handle_request(:context, "a.b.c", [], state) == {:stop, :normal, {:ok, :hello_client_a, 10000}, state}  
+
+    Application.put_env(:unimux, :routes, [{"a", 'http://127.0.0.1:8080', 10000}, {"a.b", "http://127.0.0.1:8081", 20000}])
+    assert UniMux.handle_request(:context, "a.b.c", [], state) == {:stop, :normal, {:ok, :"hello_client_a.b", 20000}, state}
   end
 
   test "router" do
     id = 1
     assert {:ok, UniMux.name(), id} == UniMux.Router.route(context(session_id: id), :req, :uri)
+  end
+
+  test "server_timeout" do
+    assert 10500 == Application.get_env(:hello, :server_timeout)
   end
 end


### PR DESCRIPTION
Example:

```
route.api1.pattern = API1
route.api1.target = http://127.0.0.1:8081
route.api1.timeout = 30000
```

And server timeout will be set automatically from maximum value of
client's timeouts.
