### PR TITLE
Add default timeout for routes

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -5,7 +5,8 @@ use Mix.Config
 
 config :unimux,
   routes: [{"APIPrefix", 'http://127.0.0.1:8080', 10000}],
-  listen: 'zmq-tcp://127.0.0.1:20000'
+  listen: 'zmq-tcp://127.0.0.1:20000',
+  default_timeout: 10000
 
 metricman_config = "deps/metricman/config/config.exs"
 if File.exists? metricman_config do

--- a/config/unimux.schema.exs
+++ b/config/unimux.schema.exs
@@ -12,6 +12,11 @@
       datatype: :charlist,
       default: "http://127.0.0.1:20000"
     ],
+    "default_timeout": [
+      to: "unimux.default_timeout",
+      datatype: :integer,
+      default: 10000
+    ],
     "route.*": [
       to: "unimux.routes",
       datatype: [:complex],
@@ -33,7 +38,7 @@
       doc: "Timeout for client call for API endpoint in ms",
       to: "unimux.routes",
       datatype: :integer,
-      default: 10000
+      default: :undefined
     ]
   ],
   translations: [


### PR DESCRIPTION
10000 ms by default, we can change it:

```
unimux.default_timeout = 30000
```
